### PR TITLE
feat: render block-level markdown in placeholder values

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,11 @@ This node provides powerful Markdown to Google Docs conversion with advanced for
   - Use text placeholders like `{{key}}` anywhere in your template (headers, footers, body).
   - Provide a JSON object with corresponding key-value pairs (e.g., `{ "key": "Your Value" }`) to replace them dynamically.
   - Supports n8n expressions for generating values on the fly.
+- **Markdown in Placeholder Values**:
+  - Turn on **Parse Placeholder Values As Markdown** to render block-level markdown inside placeholder values: headings, lists, tables, blockquotes, code fences, and multi-paragraph content all become formatted Google Docs content.
+  - The rule is block-only. A placeholder value triggers markdown rendering if it contains a newline, or starts with `#`, `-`, `*`, `>`, `|`, or a code fence. A value like `# Quarterly Report` on its own line becomes a real heading.
+  - Single-line values with only inline markers (`**bold**`, `_italic_`, `[link](url)`) stay as literal text swaps, so a placeholder sitting mid-sentence keeps its surrounding paragraph intact. Put markdown placeholders on their own line in the template.
+  - Default is off — every value is a literal text swap, exactly as before. This toggle only affects the JSON placeholders, not the Main Content Placeholder below.
 - **Smart Markdown Injection**:
   - By default, your Markdown input replaces the entire body of the template.
   - Optionally, specify a "Main Content Placeholder" (e.g., `{{MainContent}}`) in your template body. The node will replace only this specific placeholder with your rendered Markdown.
@@ -324,6 +329,7 @@ The `additionalOptions` parameter provides access to advanced features like temp
   - **`placeholders`** (`collection`): Enables placeholder replacement within the selected template.
     - **`placeholderSettings`** (`fixedCollection`): Contains settings for placeholder data and Markdown injection.
       - **`placeholderData`** (`json`): A JSON object of key-value pairs for placeholders (e.g., `{ "key": "value" }`).
+      - **`parsePlaceholderMarkdown`** (`boolean`): Renders placeholder values that contain block-level markdown as formatted Google Docs content. Block-level means a newline, or a value starting with `#`, `-`, `*`, `>`, `|`, or a code fence. Single-line values without those markers stay as literal text swaps. Defaults to off.
       - **`useMarkdownInput`** (`boolean`): Whether to use the Markdown content. If disabled, the node only replaces placeholders.
       - **`mainContentPlaceholder`** (`string`): The specific placeholder (e.g., `{{MainContent}}`) to be replaced by the Markdown content. If not specified, the entire document body is replaced.
 
@@ -396,6 +402,7 @@ npm link n8n-nodes-md-to-docs
 - [x] **Checkbox Lists**: Native Google Docs checkboxes for `- [x]` and `- [ ]` syntax with proper checked/unchecked states
 - [x] **Image Support**: Convert Markdown images to Google Docs embedded images (URL-based only)
 - [x] **Template and Text Placeholder System**: Create documents from a template, preserving headers/footers and replacing dynamic text `{{placeholders}}`.
+- [x] **Markdown in Placeholder Values**: Opt-in rendering of block-level markdown (headings, lists, tables) inside `{{placeholder}}` values, not just the main content.
 - [x] **Enhanced List Support**: Flawless rendering of multi-line and deeply nested list items with accurate inline formatting.
 - [x] **Google Docs Export**: Export existing Google Docs to Markdown, PDF, or Plain Text with automatic output handling and optional Drive save.
 

--- a/nodes/MarkdownToGoogleDocs/MarkdownToDocsDescription.ts
+++ b/nodes/MarkdownToGoogleDocs/MarkdownToDocsDescription.ts
@@ -242,11 +242,33 @@ const additionalOptions: INodeProperties = {
 											displayName: 'Values',
 											values: [
 												{
+													displayName: 'Main Content Placeholder',
+													name: 'mainContentPlaceholder',
+													type: 'string',
+													default: '{{MainContent}}',
+													description:
+														'The exact token in your template (e.g. `{{MainContent}}`) that will be replaced by the parsed Markdown Input. The token must sit on its own line in the template — its containing paragraph is replaced by the rendered markdown blocks.',
+													displayOptions: {
+														show: {
+															useMarkdownInput: [true],
+														},
+													},
+												},
+												{
+													displayName: 'Parse Placeholder Values As Markdown',
+													name: 'parsePlaceholderMarkdown',
+													type: 'boolean',
+													default: false,
+													description:
+														'Whether placeholder values containing block-level markdown should be rendered as formatted Google Docs content. Block-level means a value with a newline, or one that starts with a heading (`#`), list (`-`, `*`, `1.`), blockquote (`>`), table (`|`), or code fence (```` ``` ````). Single-line values without those markers — including ones with only inline markdown like `**bold**` or `[link](URL)` — are still inserted as literal text via a direct text swap, so they stay inside their surrounding paragraph. Off keeps every value as a literal text swap (the original behavior).',
+												},
+												{
 													displayName: 'Placeholder Data (JSON)',
 													name: 'placeholderData',
 													type: 'json',
 													default: '{}',
-													description: 'A JSON object of key-value pairs for placeholders',
+													description:
+														'A JSON object of key-value pairs for placeholders. By default every value is inserted as literal text (e.g. `**Acme**` will show the asterisks). Enable "Parse Placeholder Values As Markdown" below to render block-level markdown (headings, lists, tables, multi-line content) as formatted Google Docs.',
 													hint: `e.g. { "placeholderName": "placeholderValue", "Date": "{{ $now.format('yyyy-MM-dd') }}" }`,
 												},
 												{
@@ -254,19 +276,8 @@ const additionalOptions: INodeProperties = {
 													name: 'useMarkdownInput',
 													type: 'boolean',
 													default: true,
-													description: 'Whether to use the Markdown Input field content',
-												},
-												{
-													displayName: 'Main Content Placeholder',
-													name: 'mainContentPlaceholder',
-													type: 'string',
-													default: '{{MainContent}}',
-													description: 'The placeholder to be replaced by the Markdown content',
-													displayOptions: {
-														show: {
-															useMarkdownInput: [true],
-														},
-													},
+													description:
+														'Whether the Markdown Input field above should be parsed and injected into the template at the Main Content Placeholder position below. This is independent of the per-placeholder markdown setting above — Main Content always uses the full markdown pipeline.',
 												},
 											],
 										},
@@ -404,7 +415,8 @@ const exportGoogleDocOperation: INodeProperties[] = [
 				displayName: 'Link',
 				name: 'url',
 				type: 'string',
-				placeholder: 'e.g. https://docs.google.com/document/d/195j9eDD3ccgjQRttHhYymF12r86v_EVYb-2G_9oPaAC/edit',
+				placeholder:
+					'e.g. https://docs.google.com/document/d/195j9eDD3ccgjQRttHhYymF12r86v_EVYb-2G_9oPaAC/edit',
 				extractValue: {
 					type: 'regex',
 					regex: /(?:https?:\/\/)?(?:www\.)?docs\.google\.com\/document\/d\/([a-zA-Z0-9-_]+)/,
@@ -478,7 +490,8 @@ const exportGoogleDocOperation: INodeProperties[] = [
 				operation: ['exportGoogleDoc'],
 			},
 		},
-		description: 'Custom filename for the exported file (optional - will use document title if empty)',
+		description:
+			'Custom filename for the exported file (optional - will use document title if empty)',
 	},
 	{
 		displayName: 'Output Options',
@@ -512,7 +525,8 @@ const exportGoogleDocOperation: INodeProperties[] = [
 						displayName: 'Link',
 						name: 'url',
 						type: 'string',
-						placeholder: 'e.g. https://drive.google.com/drive/folders/1Tx9WHbA3wBpPB4C_HcoZDH9WZFWYxAMU',
+						placeholder:
+							'e.g. https://drive.google.com/drive/folders/1Tx9WHbA3wBpPB4C_HcoZDH9WZFWYxAMU',
 						extractValue: {
 							type: 'regex',
 							regex: GOOGLE_DRIVE_FOLDER_URL_REGEX,
@@ -676,7 +690,6 @@ const createDocumentOperation: INodeProperties[] = [
 	},
 ];
 
-
 export const markdownToDocsFields: INodeProperties[] = [
 	/* -------------------------------------------------------------------------- */
 	/*                        convertToApiRequests Operation                      */
@@ -702,5 +715,4 @@ export const markdownToDocsFields: INodeProperties[] = [
 	/*                        Additional Options                                  */
 	/* -------------------------------------------------------------------------- */
 	additionalOptions,
-
 ];

--- a/nodes/MarkdownToGoogleDocs/MarkdownToGoogleDocs.node.ts
+++ b/nodes/MarkdownToGoogleDocs/MarkdownToGoogleDocs.node.ts
@@ -73,7 +73,8 @@ export class MarkdownToGoogleDocs implements INodeType {
 						const outputFileName = this.getNodeParameter('outputFileName', itemIndex, '') as string;
 						const outputOptions = this.getNodeParameter('outputOptions', itemIndex, {}) as any;
 
-						const documentId = typeof documentIdParam === 'object' ? documentIdParam.value : documentIdParam;
+						const documentId =
+							typeof documentIdParam === 'object' ? documentIdParam.value : documentIdParam;
 
 						if (!documentId) {
 							throw new NodeOperationError(this.getNode(), 'Document ID is required', {
@@ -128,7 +129,7 @@ export class MarkdownToGoogleDocs implements INodeType {
 							itemIndex,
 							{},
 						) as IAdditionalOptions;
-						
+
 						result = MarkdownProcessor.convertMarkdownToApiRequests(
 							markdownInput,
 							documentTitle,
@@ -186,6 +187,7 @@ export class MarkdownToGoogleDocs implements INodeType {
 
 						let placeholderData: string | object | undefined;
 						let mainContentPlaceholder: string | undefined;
+						let parsePlaceholderMarkdown = false;
 
 						if (usePlaceholders) {
 							placeholderData =
@@ -194,6 +196,9 @@ export class MarkdownToGoogleDocs implements INodeType {
 							mainContentPlaceholder =
 								additionalOptions.templateSettings!.values.placeholders!.placeholderSettings!.values
 									.mainContentPlaceholder;
+							parsePlaceholderMarkdown =
+								additionalOptions.templateSettings!.values.placeholders!.placeholderSettings!.values
+									.parsePlaceholderMarkdown === true;
 
 							if (typeof placeholderData === 'string') {
 								try {
@@ -231,6 +236,7 @@ export class MarkdownToGoogleDocs implements INodeType {
 							usePlaceholders && useMarkdownInput ? mainContentPlaceholder : undefined,
 							additionalOptions.pageBreakSettings?.values?.pageBreakStrategy,
 							additionalOptions.pageBreakSettings?.values?.customPageBreakText,
+							parsePlaceholderMarkdown,
 						);
 						break;
 

--- a/nodes/MarkdownToGoogleDocs/google-docs-api.ts
+++ b/nodes/MarkdownToGoogleDocs/google-docs-api.ts
@@ -17,6 +17,7 @@ export class GoogleDocsAPI {
 		mainContentPlaceholder?: string,
 		pageBreakStrategy?: string,
 		customPageBreakText?: string,
+		parsePlaceholderMarkdown: boolean = false,
 	): Promise<DocumentCreationResult> {
 		try {
 			let documentId: string;
@@ -40,32 +41,125 @@ export class GoogleDocsAPI {
 				);
 				documentId = copyResponse.id;
 
-				// Step 2: Replace simple placeholders in a dedicated batch
+				// Step 2: Replace placeholders.
+				// Phase 2a — plain text swap via replaceAllText. Handles every placeholder when
+				// the markdown toggle is off, and the no-block-markdown subset when it's on.
+				// Phase 2b — for placeholders with block-level markdown values (only when the
+				// toggle is on), walk the doc, collect every occurrence, then issue a single
+				// batchUpdate in reverse-index order so earlier indices stay valid as later
+				// edits land.
 				if (placeholderData && Object.keys(placeholderData).length > 0) {
-					const placeholderRequests: GoogleDocsRequest[] = [];
+					const plainRequests: GoogleDocsRequest[] = [];
+					const markdownKeys: Array<{ token: string; value: string }> = [];
+
 					for (const key in placeholderData) {
-						if (
-							Object.prototype.hasOwnProperty.call(placeholderData, key) &&
-							`{{${key}}}` !== mainContentPlaceholder
-						) {
-							placeholderRequests.push({
+						if (!Object.prototype.hasOwnProperty.call(placeholderData, key)) continue;
+						const token = `{{${key}}}`;
+						if (token === mainContentPlaceholder) continue;
+
+						const rawValue = String(placeholderData[key]);
+						const isMarkdown =
+							parsePlaceholderMarkdown && MarkdownProcessor.hasBlockMarkdown(rawValue);
+
+						if (isMarkdown) {
+							markdownKeys.push({ token, value: rawValue });
+						} else {
+							plainRequests.push({
 								replaceAllText: {
-									containsText: { text: `{{${key}}}`, matchCase: false },
-									replaceText: String(placeholderData[key]),
+									containsText: { text: token, matchCase: false },
+									replaceText: rawValue,
 								},
 							});
 						}
 					}
-					if (placeholderRequests.length > 0) {
+
+					// Phase 2a
+					if (plainRequests.length > 0) {
 						await executeFunctions.helpers.httpRequestWithAuthentication.call(
 							executeFunctions,
 							'googleDocsOAuth2Api',
 							{
 								method: 'POST' as IHttpRequestMethods,
 								url: `https://docs.googleapis.com/v1/documents/${documentId}:batchUpdate`,
-								body: { requests: placeholderRequests },
+								body: { requests: plainRequests },
 							},
 						);
+					}
+
+					// Phase 2b — reverse-order walk for markdown-bound placeholders.
+					if (markdownKeys.length > 0) {
+						const doc = await executeFunctions.helpers.httpRequestWithAuthentication.call(
+							executeFunctions,
+							'googleDocsOAuth2Api',
+							{
+								method: 'GET' as IHttpRequestMethods,
+								url: `https://docs.googleapis.com/v1/documents/${documentId}?fields=body.content`,
+							},
+						);
+
+						type Occurrence = { startIndex: number; length: number; value: string };
+						const occurrences: Occurrence[] = [];
+
+						if (doc.body && doc.body.content) {
+							for (const element of doc.body.content) {
+								if (!element.paragraph) continue;
+								for (const run of element.paragraph.elements) {
+									if (!run.textRun || typeof run.textRun.content !== 'string') continue;
+									const runStart = run.startIndex || 0;
+									const runText: string = run.textRun.content;
+									const runTextLower = runText.toLowerCase();
+
+									for (const { token, value } of markdownKeys) {
+										const tokenLower = token.toLowerCase();
+										let searchFrom = 0;
+										while (true) {
+											const hit = runTextLower.indexOf(tokenLower, searchFrom);
+											if (hit === -1) break;
+											occurrences.push({
+												startIndex: runStart + hit,
+												length: token.length,
+												value,
+											});
+											searchFrom = hit + token.length;
+										}
+									}
+								}
+							}
+						}
+
+						if (occurrences.length > 0) {
+							occurrences.sort((a, b) => b.startIndex - a.startIndex);
+
+							const markdownRequests: GoogleDocsRequest[] = [];
+							for (const occ of occurrences) {
+								markdownRequests.push({
+									deleteContentRange: {
+										range: {
+											startIndex: occ.startIndex,
+											endIndex: occ.startIndex + occ.length,
+										},
+									},
+								});
+
+								const conversion = MarkdownProcessor.convertMarkdownToApiRequests(
+									occ.value,
+									'',
+									'single',
+									occ.startIndex,
+								);
+								markdownRequests.push(...conversion.batchUpdateRequest.requests);
+							}
+
+							await executeFunctions.helpers.httpRequestWithAuthentication.call(
+								executeFunctions,
+								'googleDocsOAuth2Api',
+								{
+									method: 'POST' as IHttpRequestMethods,
+									url: `https://docs.googleapis.com/v1/documents/${documentId}:batchUpdate`,
+									body: { requests: markdownRequests },
+								},
+							);
+						}
 					}
 				}
 
@@ -300,20 +394,21 @@ export class GoogleDocsAPI {
 				},
 			);
 			// Test Google Shared Drives access
-			const sharedDrivesResponse = await executeFunctions.helpers.httpRequestWithAuthentication.call(
-				executeFunctions,
-				'googleDocsOAuth2Api',
-				{
-					method: 'GET' as IHttpRequestMethods,
-					url: 'https://www.googleapis.com/drive/v3/drives',
-					qs: {
-						pageSize: 1,
-						fields: 'drives(name,id)',
-						includeItemsFromAllDrives: true,
-						supportsAllDrives: true,
+			const sharedDrivesResponse =
+				await executeFunctions.helpers.httpRequestWithAuthentication.call(
+					executeFunctions,
+					'googleDocsOAuth2Api',
+					{
+						method: 'GET' as IHttpRequestMethods,
+						url: 'https://www.googleapis.com/drive/v3/drives',
+						qs: {
+							pageSize: 1,
+							fields: 'drives(name,id)',
+							includeItemsFromAllDrives: true,
+							supportsAllDrives: true,
+						},
 					},
-				},
-			);
+				);
 			// Test Google Docs API access by trying to list recent documents
 			const docsResponse = await executeFunctions.helpers.httpRequestWithAuthentication.call(
 				executeFunctions,

--- a/nodes/MarkdownToGoogleDocs/markdown-processor.ts
+++ b/nodes/MarkdownToGoogleDocs/markdown-processor.ts
@@ -16,6 +16,18 @@ import type {
 
 export class MarkdownProcessor {
 	/**
+	 * Returns true when the value contains block-level markdown that should be parsed
+	 * (multi-line content, or a line that starts with a heading/list/blockquote/table/fence marker).
+	 * Inline-only markers like **bold**, _italic_, `code`, and [link](url) intentionally do NOT
+	 * trigger this — those values stay as literal text swaps to preserve their surrounding paragraph.
+	 */
+	static hasBlockMarkdown(value: string): boolean {
+		if (!value) return false;
+		if (/\n/.test(value)) return true;
+		return /^\s*(#{1,6}\s|[-+*]\s|\d+\.\s|>\s|\||```|~~~)/.test(value);
+	}
+
+	/**
 	 * Convert markdown to Google Docs API requests using HTML parsing approach
 	 * This method first converts markdown to HTML, then parses HTML elements
 	 * to generate appropriate Google Docs API requests for each element.
@@ -58,7 +70,7 @@ export class MarkdownProcessor {
 					insertIndex,
 					$,
 					pageBreakStrategy,
-					{ firstH1Found }
+					{ firstH1Found },
 				);
 				if (elementRequests && elementRequests.length > 0) {
 					requests.push(...elementRequests);
@@ -201,7 +213,7 @@ export class MarkdownProcessor {
 		const shouldAddPageBreak = this.shouldAddPageBreakBeforeHeading(
 			element.tagName!.toUpperCase(),
 			pageBreakStrategy,
-			headingTracker
+			headingTracker,
 		);
 
 		let headingInsertIndex = insertIndex;
@@ -672,8 +684,7 @@ export class MarkdownProcessor {
 				updateParagraphStyle: {
 					range: {
 						startIndex: firstItemMeta.startIndex,
-						endIndex:
-							firstItemMeta.startIndex + firstItemMeta.textToInsert.length,
+						endIndex: firstItemMeta.startIndex + firstItemMeta.textToInsert.length,
 					},
 					paragraphStyle: {
 						spaceAbove: { magnitude: 12, unit: 'PT' },

--- a/nodes/MarkdownToGoogleDocs/types.ts
+++ b/nodes/MarkdownToGoogleDocs/types.ts
@@ -163,6 +163,7 @@ export interface IAdditionalOptions {
 				placeholderSettings?: {
 					values: {
 						placeholderData?: string | object;
+						parsePlaceholderMarkdown?: boolean;
 						useMarkdownInput?: boolean;
 						mainContentPlaceholder?: string;
 					};


### PR DESCRIPTION
Closes #2.

Adds an opt-in "Parse Placeholder Values As Markdown" toggle in Placeholder Settings. When on, placeholder values containing block-level markdown render as formatted Google Docs content. Default is off, so existing workflows behave identically.

![Placeholder Settings UI with the new toggle](https://raw.githubusercontent.com/meetbryce/n8n-nodes-md-to-docs/fc28869/screenshots/placeholder-settings-ui.png)

## The rule

Block-only: a value with a newline, or one starting with `#`, `-`, `*`, `>`, `|`, or a code fence triggers the markdown path. Single-line values with only inline markers (`**bold**`, `_italic_`, `[link](URL)`) stay as literal text swaps. Inline placeholders mid-sentence stay inside their paragraph.

This avoids the "stars in a customer name break the paragraph" problem — you only get formatted blocks when the placeholder owns its own line.

## Implementation

Splits the placeholder step into two phases:

1. **Plain swap.** `replaceAllText` batch for values without block-level markdown chars. Same as today's behavior, and the only path used when the toggle is off.
2. **Markdown walk.** GET the doc once, collect every occurrence of every markdown-bound key (case-insensitive), sort descending by `startIndex`, then emit `deleteContentRange` + `MarkdownProcessor` requests in reverse-position order. Reverse order keeps earlier indices valid as later edits land.

Main Content Placeholder is untouched and runs in its own subsequent phase. A new `MarkdownProcessor.hasBlockMarkdown` helper picks the path per value.

## Test plan

- [ ] Toggle off: every value is a literal swap (existing behavior).
- [ ] Toggle on, `"Acme"` → inline swap.
- [ ] Toggle on, `"**Acme**"` → literal asterisks, paragraph preserved.
- [ ] Toggle on, `"# Heading"` → real heading.
- [ ] Toggle on, `"- one\n- two"` → bulleted list.
- [ ] Two markdown placeholders at different positions both render (verifies the reverse-order walk).
- [ ] Multiple occurrences of the same key all render.
- [ ] Main Content Placeholder still works with `useMarkdownInput`.
- [ ] Keys in the JSON that don't appear in the template are silently skipped.

Built and tested against my own n8n instance with templates that mix plain placeholders, markdown placeholders, and Main Content. Works as expected.
